### PR TITLE
Bump json5 and babel-loader in /stepped-solutions/45 - Finished App

### DIFF
--- a/stepped-solutions/45 - Finished App/package-lock.json
+++ b/stepped-solutions/45 - Finished App/package-lock.json
@@ -42,7 +42,7 @@
         "@babel/core": "7.16.0",
         "@babel/preset-env": "7.16.0",
         "autoprefixer": "10.4.0",
-        "babel-loader": "8.2.3",
+        "babel-loader": "8.3.0",
         "concurrently": "6.3.0",
         "css-loader": "6.5.1",
         "mini-css-extract-plugin": "2.4.3",
@@ -2399,20 +2399,6 @@
         "node": ">=8.9"
       }
     },
-    "node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-      "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2723,13 +2709,13 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
-      "integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "dev": true,
       "dependencies": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^1.4.0",
+        "loader-utils": "^2.0.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       },
@@ -5814,13 +5800,10 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5956,29 +5939,17 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
+        "json5": "^2.1.2"
       },
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
+        "node": ">=8.9.0"
       }
     },
     "node_modules/locate-path": {
@@ -8230,20 +8201,6 @@
         "rework-visit": {
           "optional": true
         }
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-      "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/resolve-url-loader/node_modules/picocolors": {
@@ -12072,19 +12029,6 @@
       "requires": {
         "loader-utils": "^2.0.0",
         "regex-parser": "^2.2.11"
-      },
-      "dependencies": {
-        "loader-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-          "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        }
       }
     },
     "ajv": {
@@ -12342,13 +12286,13 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
-      "integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^3.3.1",
-        "loader-utils": "^1.4.0",
+        "loader-utils": "^2.0.0",
         "make-dir": "^3.1.0",
         "schema-utils": "^2.6.5"
       }
@@ -14660,13 +14604,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -14772,25 +14713,14 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
+        "json5": "^2.1.2"
       }
     },
     "locate-path": {
@@ -16517,17 +16447,6 @@
         "source-map": "0.6.1"
       },
       "dependencies": {
-        "loader-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.1.tgz",
-          "integrity": "sha512-g4miPa9uUrZz4iElkaVJgDFwKJGh8aQGM7pUL4ejXl6cu7kSb30seQOVGNMP6sW8j7DW77X68hJZ+GM7UGhXeQ==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "picocolors": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",

--- a/stepped-solutions/45 - Finished App/package.json
+++ b/stepped-solutions/45 - Finished App/package.json
@@ -52,7 +52,7 @@
     "@babel/core": "7.16.0",
     "@babel/preset-env": "7.16.0",
     "autoprefixer": "10.4.0",
-    "babel-loader": "8.2.3",
+    "babel-loader": "8.3.0",
     "concurrently": "6.3.0",
     "css-loader": "6.5.1",
     "mini-css-extract-plugin": "2.4.3",


### PR DESCRIPTION
Bumps [json5](https://github.com/json5/json5) to 2.2.3 and updates ancestor dependency [babel-loader](https://github.com/babel/babel-loader). These dependencies need to be updated together.


Updates `json5` from 2.2.0 to 2.2.3
- [Release notes](https://github.com/json5/json5/releases)
- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)
- [Commits](https://github.com/json5/json5/compare/v2.2.0...v2.2.3)

Updates `babel-loader` from 8.2.3 to 8.3.0
- [Release notes](https://github.com/babel/babel-loader/releases)
- [Changelog](https://github.com/babel/babel-loader/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel-loader/compare/v8.2.3...v8.3.0)

---
updated-dependencies:
- dependency-name: json5 dependency-type: indirect
- dependency-name: babel-loader dependency-type: direct:development ...